### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-nat.opam
+++ b/mirage-nat.opam
@@ -22,7 +22,7 @@ depends: [
   "logs"
   "lru" {>= "0.3.0"}
   "ppx_deriving" {build & >= "4.2" }
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "tcpip" { >= "3.7.2" }
   "ethernet" { >= "2.0.0" }
   "arp"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.