### PR TITLE
fragment and reassembly

### DIFF
--- a/example/config.ml
+++ b/example/config.ml
@@ -42,7 +42,7 @@ let main = foreign "Unikernel.Main" ~packages (network  @-> network  @->
                                                ethernet @-> ethernet @->
                                                arpv4    @-> arpv4    @->
                                                ipv4     @-> ipv4     @->
-                                               random   @-> job)
+                                               random   @-> mclock   @-> job)
 
 (* we need to pass each of the network-related impls we've made to the
    unikernel, so that it can start the appropriate listeners. *)
@@ -51,5 +51,5 @@ let () = register "simple-nat" [ main
                                  $ public_ethernet $ private_ethernet
                                  $ public_arpv4    $ private_arpv4
                                  $ public_ipv4     $ private_ipv4
-                                 $ default_random
+                                 $ default_random  $ default_monotonic_clock
                                ]

--- a/example/unikernel.ml
+++ b/example/unikernel.ml
@@ -168,7 +168,7 @@ module Main
       and input =
         Public_ethernet.input
           ~arpv4:(Public_arpv4.input public_arpv4)
-          ~ipv4:(Util.try_decompose ~cache ~now:Clock.elapsed_ns (ingest_public table))
+          ~ipv4:(Util.try_decompose cache ~now:Clock.elapsed_ns (ingest_public table))
           ~ipv6:(fun _ -> Lwt.return_unit)
           public_ethernet
       in
@@ -185,7 +185,7 @@ module Main
       and input =
         Private_ethernet.input
           ~arpv4:(Private_arpv4.input private_arpv4)
-          ~ipv4:(Util.try_decompose ~cache ~now:Clock.elapsed_ns (ingest_private table))
+          ~ipv4:(Util.try_decompose cache ~now:Clock.elapsed_ns (ingest_private table))
           ~ipv6:(fun _ -> Lwt.return_unit)
           private_ethernet
       in

--- a/example/util.ml
+++ b/example/util.ml
@@ -4,6 +4,10 @@
 
 let get_dst (`IPv4 (packet, _) : Nat_packet.t) = packet.Ipv4_packet.dst
 
-let try_decompose f packet = match Nat_packet.of_ipv4_packet packet with
-  | Error _ -> Lwt.return_unit
-  | Ok packet -> f packet
+let try_decompose ~cache ~now f packet =
+  match Nat_packet.of_ipv4_packet ~cache ~now:(now ()) packet with
+  | Error e ->
+    Logs.err (fun m -> m "of_ipv4_packet error %a" Nat_packet.pp_error e);
+    Lwt.return_unit
+  | Ok Some packet -> f packet
+  | Ok None -> Lwt.return_unit

--- a/example/util.ml
+++ b/example/util.ml
@@ -4,8 +4,8 @@
 
 let get_dst (`IPv4 (packet, _) : Nat_packet.t) = packet.Ipv4_packet.dst
 
-let try_decompose ~cache ~now f packet =
-  match Nat_packet.of_ipv4_packet ~cache ~now:(now ()) packet with
+let try_decompose cache ~now f packet =
+  match Nat_packet.of_ipv4_packet cache ~now:(now ()) packet with
   | Error e ->
     Logs.err (fun m -> m "of_ipv4_packet error %a" Nat_packet.pp_error e);
     Lwt.return_unit

--- a/lib/nat_packet.ml
+++ b/lib/nat_packet.ml
@@ -29,34 +29,37 @@ let icmp_type header =
   | Parameter_problem
   | Destination_unreachable -> `Error
 
-let of_ipv4_packet packet : (t, error) result =
+let of_ipv4_packet ~cache ~now packet : (t option, error) result =
   match Ipv4_packet.Unmarshal.of_cstruct packet with
   | Error e ->
     Error (fun f -> Fmt.pf f "Failed to parse IPv4 packet: %s@.%a" e Cstruct.hexdump_pp packet)
-  | Ok (ip, transport) ->
-    match Ipv4_packet.(Unmarshal.int_to_protocol ip.proto) with
-    | Some `TCP ->
-      begin match Tcp.Tcp_packet.Unmarshal.of_cstruct transport with
-        | Error e ->
-          Error (fun f -> Fmt.pf f "Failed to parse TCP packet: %s@.%a" e Cstruct.hexdump_pp transport)
-        | Ok (tcp, payload) -> Ok (`IPv4 (ip, `TCP (tcp, payload)))
-      end
-    | Some `UDP ->
-      begin match Udp_packet.Unmarshal.of_cstruct transport with
-        | Error e ->
-          Error (fun f -> Fmt.pf f "Failed to parse UDP packet: %s@.%a" e Cstruct.hexdump_pp transport)
-        | Ok (udp, payload) -> Ok (`IPv4 (ip, `UDP (udp, payload)))
-      end
-    | Some `ICMP ->
-      begin match Icmpv4_packet.Unmarshal.of_cstruct transport with
-        | Error e ->
-          Error (fun f -> Fmt.pf f "Failed to parse ICMP packet: %s@.%a" e Cstruct.hexdump_pp transport)
-        | Ok (header, payload) -> Ok (`IPv4 (ip, `ICMP (header, payload)))
-      end
-    | _ ->
-      Error (fun f -> Fmt.pf f "Ignoring non-TCP/UDP packet: %a" Ipv4_packet.pp ip)
+  | Ok (ip_packet, payload) ->
+    match Fragments.process cache now ip_packet payload with
+    | None -> Ok None
+    | Some (ip, transport) ->
+      match Ipv4_packet.(Unmarshal.int_to_protocol ip.proto) with
+      | Some `TCP ->
+        begin match Tcp.Tcp_packet.Unmarshal.of_cstruct transport with
+          | Error e ->
+            Error (fun f -> Fmt.pf f "Failed to parse TCP packet: %s@.%a" e Cstruct.hexdump_pp transport)
+          | Ok (tcp, payload) -> Ok (Some (`IPv4 (ip, `TCP (tcp, payload))))
+        end
+      | Some `UDP ->
+        begin match Udp_packet.Unmarshal.of_cstruct transport with
+          | Error e ->
+            Error (fun f -> Fmt.pf f "Failed to parse UDP packet: %s@.%a" e Cstruct.hexdump_pp transport)
+          | Ok (udp, payload) -> Ok (Some (`IPv4 (ip, `UDP (udp, payload))))
+        end
+      | Some `ICMP ->
+        begin match Icmpv4_packet.Unmarshal.of_cstruct transport with
+          | Error e ->
+            Error (fun f -> Fmt.pf f "Failed to parse ICMP packet: %s@.%a" e Cstruct.hexdump_pp transport)
+          | Ok (header, payload) -> Ok (Some (`IPv4 (ip, `ICMP (header, payload))))
+        end
+      | _ ->
+        Error (fun f -> Fmt.pf f "Ignoring non-TCP/UDP packet: %a" Ipv4_packet.pp ip)
 
-let of_ethernet_frame frame =
+let of_ethernet_frame ~cache ~now frame =
   match Ethernet_packet.Unmarshal.of_cstruct frame with
   | Error e ->
     Error (fun f -> Fmt.pf f "Failed to parse ethernet frame: %s@.%a" e Cstruct.hexdump_pp frame)
@@ -64,7 +67,7 @@ let of_ethernet_frame frame =
     match eth.Ethernet_packet.ethertype with
     | `ARP | `IPv6 ->
       Error (fun f -> Fmt.pf f "Ignoring a non-IPv4 frame: %a" Cstruct.hexdump_pp frame)
-    | `IPv4 -> of_ipv4_packet packet
+    | `IPv4 -> of_ipv4_packet ~cache ~now packet
 
 let decompose_transport = function
   | `ICMP (_, icmp_payload) -> Icmpv4_wire.sizeof_icmpv4, (Cstruct.len icmp_payload)
@@ -73,26 +76,26 @@ let decompose_transport = function
     let options_length = Tcp.Options.lenv tcp_header.Tcp.Tcp_packet.options in
     (Tcp.Tcp_wire.sizeof_tcp + options_length), (Cstruct.len tcp_payload)
 
-let to_cstruct ((`IPv4 (ip, transport)):t) =
+let to_cstruct ?(mtu = 1500) ((`IPv4 (ip, transport)):t) =
   let {Ipv4_packet.src; dst; _} = ip in
   (* Calculate required buffer size *)
   let transport_header_len, _ = decompose_transport transport in
   (* Create buffers representing the transport header, and return it in a list with the payload.
      We do the transport layer first so that we calculate the correct checksum when we
      write the IP layer. *)
-  let transport =
+  let transport_hdr, transport_payload =
     match transport with
     | `ICMP (icmp_header, payload) ->
       let transport_header = Icmpv4_packet.Marshal.make_cstruct icmp_header ~payload in
       Logs.debug (fun f -> f "ICMP header written: %a" Cstruct.hexdump_pp transport_header);
-      [transport_header; payload]
+      transport_header, payload
     | `UDP (udp_header, udp_payload) ->
       let pseudoheader = Ipv4_packet.Marshal.pseudoheader ~src ~dst ~proto:`UDP (Cstruct.len udp_payload + Udp_wire.sizeof_udp) in
       let transport_header = Udp_packet.Marshal.make_cstruct
         ~pseudoheader udp_header
         ~payload:udp_payload in
       Logs.debug (fun f -> f "UDP header written: %a" Cstruct.hexdump_pp transport_header);
-      [transport_header; udp_payload]
+      transport_header, udp_payload
     | `TCP (tcp_header, tcp_payload) ->
       let options_length = transport_header_len - Tcp.Tcp_wire.sizeof_tcp in
       let pseudoheader = Ipv4_packet.Marshal.pseudoheader ~src ~dst ~proto:`TCP (Tcp.Tcp_wire.sizeof_tcp + options_length + Cstruct.len tcp_payload) in
@@ -100,67 +103,95 @@ let to_cstruct ((`IPv4 (ip, transport)):t) =
         ~pseudoheader tcp_header
         ~payload:tcp_payload in
       Logs.debug (fun f -> f "TCP header written: %a" Cstruct.hexdump_pp transport_header);
-      [transport_header; tcp_payload]
+      transport_header, tcp_payload
   in
-  let ip_header = Ipv4_packet.Marshal.make_cstruct ~payload_len:(Cstruct.lenv transport) ip in
-  ip_header :: transport
+  let payload = Cstruct.append transport_hdr transport_payload in
+  let plen = Cstruct.len payload in
+  let pmtu = mtu - Ipv4_wire.sizeof_ipv4 in
+  let need_fragment = plen > pmtu in
+  if need_fragment && ip.Ipv4_packet.off land 0x4000 > 0 then
+    Error (fun f -> Fmt.pf f "would need to fragment, but don't fragment is set")
+  else
+    let ip = if need_fragment then { ip with off = 0x2000 } else ip in
+    let first, rest = if need_fragment then Cstruct.split payload pmtu else payload, Cstruct.empty in
+    let ip_header = Ipv4_packet.Marshal.make_cstruct ~payload_len:(Cstruct.len first) ip in
+    let frags = if need_fragment then Fragments.fragment ~mtu ip rest else [] in
+    Ok (Cstruct.append ip_header first :: frags)
 
 let into_cstruct ((`IPv4 (ip, transport)):t) full_buffer =
   let open Rresult.R in
   let {Ipv4_packet.src; dst; _} = ip in
+  let mtu = Cstruct.len full_buffer in
   (* Calculate required buffer size *)
   let ip_header_len = Ipv4_wire.sizeof_ipv4 + Cstruct.len ip.Ipv4_packet.options in
   let transport_header_len, transport_payload_len = decompose_transport transport in
-  let length_check total_len buf =
-    if total_len > Cstruct.len buf then
-      Error (fun f -> Fmt.pf f "Needed %d bytes to represent the packet, but buffer of insufficient size (%d) was provided" total_len (Cstruct.len buf))
-    else Ok ()
-  in
-  (* copy the payload into the provided buffer, then write the correct transport header *)
-  let write_transport_header_and_payload transport =
-    let payload_start = ip_header_len + transport_header_len in
-    match transport with
-    | `ICMP (icmp_header, payload) -> begin
-        Cstruct.blit payload 0 full_buffer payload_start transport_payload_len;
-        match Icmpv4_packet.Marshal.into_cstruct icmp_header ~payload (Cstruct.shift full_buffer ip_header_len) with
-        | Error s -> Error (fun f -> Fmt.pf f "Error writing ICMPv4 packet: %s" s);
-        | Ok () ->
-          Logs.debug (fun f -> f "ICMP header and payload written: %a" Cstruct.hexdump_pp (Cstruct.shift full_buffer ip_header_len));
-          Ok (transport_header_len + transport_payload_len)
-      end
-    | `UDP (udp_header, udp_payload) -> begin
-        Cstruct.blit udp_payload 0 full_buffer payload_start transport_payload_len;
-        let pseudoheader = Ipv4_packet.Marshal.pseudoheader ~src ~dst ~proto:`UDP (Cstruct.len udp_payload + Udp_wire.sizeof_udp) in
-        match Udp_packet.Marshal.into_cstruct
-                ~pseudoheader ~payload:udp_payload udp_header
-                (Cstruct.shift full_buffer ip_header_len) with
-        | Error s -> Error (fun f -> Fmt.pf f "Error writing UDP packet: %s" s);
-        | Ok () ->
-          Logs.debug (fun f -> f "UDP header written: %a" Cstruct.hexdump_pp (Cstruct.sub full_buffer ip_header_len transport_header_len));
-          Ok (transport_header_len + transport_payload_len)
-      end
-    | `TCP (tcp_header, tcp_payload) -> begin
-        Cstruct.blit tcp_payload 0 full_buffer payload_start transport_payload_len;
-        (* and now transport header *)
-        let pseudoheader = Ipv4_packet.Marshal.pseudoheader ~src ~dst ~proto:`TCP
-            (transport_header_len + transport_payload_len) in
-        match Tcp.Tcp_packet.Marshal.into_cstruct
-                ~pseudoheader tcp_header
-                ~payload:tcp_payload (Cstruct.shift full_buffer ip_header_len) with
-        | Error s -> Error (fun f -> Fmt.pf f "Error writing TCP packet: %s" s);
-        | Ok written ->
-          Logs.debug (fun f -> f "TCP header written: %a" Cstruct.hexdump_pp (Cstruct.sub full_buffer ip_header_len transport_header_len));
-          Ok (written + transport_payload_len)
-      end
-  in
-  length_check (ip_header_len + transport_header_len + transport_payload_len) full_buffer >>= fun () ->
-  write_transport_header_and_payload transport >>= fun written ->
-  (* Write the IP header into the first part of the buffer. *)
-  match Ipv4_packet.Marshal.into_cstruct ~payload_len:written ip full_buffer with
-  | Error s -> Error (fun f -> Fmt.pf f "Error writing IPv4 header: %s" s)
-  | Ok () ->
-    Logs.debug (fun f -> f "IPv4 header written: %a" Cstruct.hexdump_pp (Cstruct.sub full_buffer 0 ip_header_len));
-    Ok (written + ip_header_len)
+  let total_len = ip_header_len + transport_header_len + transport_payload_len in
+  let need_fragment = total_len > mtu in
+  (* short way out: don't fragment set and buffer too small *)
+  let dont_fragment = ip.off land 0x4000 = 0x400 in
+  if dont_fragment && need_fragment then
+    Error (fun f -> Fmt.pf f "should send ICMP error back to src, would_fragment")
+  else begin
+    (* otherwise: first packet, and use Fragments to produce other ones *)
+    (* copy the payload into the provided buffer, then write the correct transport header *)
+    (* let's assume transport header fits into first packet *)
+    assert (mtu > ip_header_len + transport_header_len);
+    let this_transport_payload_len =
+      min transport_payload_len (mtu - ip_header_len - transport_header_len)
+    in
+    let write_transport_header_and_payload transport =
+      let payload_start = ip_header_len + transport_header_len in
+      match transport with
+      | `ICMP (icmp_header, payload) -> begin
+          let this, left = Cstruct.split payload this_transport_payload_len in
+          Cstruct.blit this 0 full_buffer payload_start (Cstruct.len this);
+          match Icmpv4_packet.Marshal.into_cstruct icmp_header ~payload (Cstruct.shift full_buffer ip_header_len) with
+          | Error s -> Error (fun f -> Fmt.pf f "Error writing ICMPv4 packet: %s" s);
+          | Ok () ->
+            Logs.debug (fun f -> f "ICMP header and payload written: %a" Cstruct.hexdump_pp (Cstruct.shift full_buffer ip_header_len));
+            Ok (transport_header_len + this_transport_payload_len, left)
+        end
+      | `UDP (udp_header, udp_payload) -> begin
+          let this, left = Cstruct.split udp_payload this_transport_payload_len in
+          Cstruct.blit this 0 full_buffer payload_start this_transport_payload_len;
+          let pseudoheader = Ipv4_packet.Marshal.pseudoheader ~src ~dst ~proto:`UDP (Cstruct.len udp_payload + Udp_wire.sizeof_udp) in
+          match Udp_packet.Marshal.into_cstruct
+                  ~pseudoheader ~payload:udp_payload udp_header
+                  (Cstruct.shift full_buffer ip_header_len) with
+          | Error s -> Error (fun f -> Fmt.pf f "Error writing UDP packet: %s" s);
+          | Ok () ->
+            Logs.debug (fun f -> f "UDP header written: %a" Cstruct.hexdump_pp (Cstruct.sub full_buffer ip_header_len transport_header_len));
+            Ok (transport_header_len + this_transport_payload_len, left)
+        end
+      | `TCP (tcp_header, tcp_payload) -> begin
+          let this, left = Cstruct.split tcp_payload this_transport_payload_len in
+          Cstruct.blit this 0 full_buffer payload_start this_transport_payload_len;
+          (* and now transport header *)
+          let pseudoheader = Ipv4_packet.Marshal.pseudoheader ~src ~dst ~proto:`TCP
+              (transport_header_len + transport_payload_len) in
+          match Tcp.Tcp_packet.Marshal.into_cstruct
+                  ~pseudoheader tcp_header
+                  ~payload:tcp_payload (Cstruct.shift full_buffer ip_header_len) with
+          | Error s -> Error (fun f -> Fmt.pf f "Error writing TCP packet: %s" s);
+          | Ok written ->
+            Logs.debug (fun f -> f "TCP header written: %a" Cstruct.hexdump_pp (Cstruct.sub full_buffer ip_header_len transport_header_len));
+            Ok (written + this_transport_payload_len, left)
+        end
+    in
+    write_transport_header_and_payload transport >>= fun (written, leftover) ->
+    let need_fragment = Cstruct.len leftover > 0 in
+    let off = if need_fragment then 0x2000 else 0x0000 in
+    let ip' = { ip with off } in
+    (* Write the IP header into the first part of the buffer. *)
+    match Ipv4_packet.Marshal.into_cstruct ~payload_len:written ip' full_buffer with
+    | Error s -> Error (fun f -> Fmt.pf f "Error writing IPv4 header: %s" s)
+    | Ok () ->
+      Logs.debug (fun f -> f "IPv4 header written: %a" Cstruct.hexdump_pp (Cstruct.sub full_buffer 0 ip_header_len));
+      let fragments =
+        if need_fragment then Fragments.fragment ~mtu ip' leftover else []
+      in
+      Ok (written + ip_header_len, fragments)
+  end
 
 let pp_icmp f payload = Cstruct.hexdump_pp f payload
 

--- a/lib/nat_packet.mli
+++ b/lib/nat_packet.mli
@@ -11,10 +11,10 @@ val icmp_type : Icmpv4_packet.t -> [ `Query | `Error ]
 
 val pp_error : error Fmt.t
 
-val of_ethernet_frame : cache:Fragments.Cache.t -> now:int64 -> Cstruct.t ->
+val of_ethernet_frame : Fragments.Cache.t -> now:int64 -> Cstruct.t ->
   (t option, error) result
 
-val of_ipv4_packet : cache:Fragments.Cache.t -> now:int64 -> Cstruct.t ->
+val of_ipv4_packet : Fragments.Cache.t -> now:int64 -> Cstruct.t ->
   (t option, error) result
 
 val to_cstruct : ?mtu:int -> t -> (Cstruct.t list, error) result

--- a/lib/nat_packet.mli
+++ b/lib/nat_packet.mli
@@ -11,17 +11,21 @@ val icmp_type : Icmpv4_packet.t -> [ `Query | `Error ]
 
 val pp_error : error Fmt.t
 
-val of_ethernet_frame : Cstruct.t -> (t, error) result
+val of_ethernet_frame : cache:Fragments.Cache.t -> now:int64 -> Cstruct.t ->
+  (t option, error) result
 
-val of_ipv4_packet : Cstruct.t -> (t, error) result
+val of_ipv4_packet : cache:Fragments.Cache.t -> now:int64 -> Cstruct.t ->
+  (t option, error) result
 
-val to_cstruct : t -> Cstruct.t list
+val to_cstruct : ?mtu:int -> t -> (Cstruct.t list, error) result
 (** [to_cstruct packet] is the list of cstructs representing [packet].
-It currently returns [(ip_header, transport_header, payload)] *)
+    It returns a list of fragments to be sent, or an error if fragmentation
+    was needed, but disallowed by the provided ip header. *)
 
-val into_cstruct : t -> Cstruct.t -> (int, error) result
+val into_cstruct : t -> Cstruct.t -> (int * Cstruct.t list, error) result
 (** [into_cstruct packet buf] attempts to serialize [packet] into [buf].
-On success, it will return the number of bytes written. *)
+    On success, it will return the number of bytes written and a list of further
+    fragments to be written. *)
 
 val pp : [< t] Fmt.t
 

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,6 +1,6 @@
 (executables
  (names test_rewrite)
- (libraries mirage-nat alcotest logs lwt.unix logs.fmt))
+ (libraries mirage-nat tcpip.ipv4 alcotest logs lwt.unix logs.fmt))
 
 (alias
  (name runtest)

--- a/lib_test/test_rewrite.ml
+++ b/lib_test/test_rewrite.ml
@@ -49,7 +49,7 @@ module Constructors = struct
     assert_checksum_correct raw_to_cstruct;
     assert_checksum_correct raw_into_cstruct;
     let check_packet raw =
-      match Nat_packet.of_ipv4_packet ~cache ~now:0L raw with
+      match Nat_packet.of_ipv4_packet cache ~now:0L raw with
       | Ok Some loaded when Nat_packet.equal packet loaded -> ()
       | Ok Some loaded -> Alcotest.fail (Fmt.strf "Packet changed by save/load! Saved:@.%a@.Got:@.%a"
                                            Nat_packet.pp packet
@@ -234,7 +234,7 @@ let test_add_nat_broadcast () =
   Alcotest.check add_result "Ignore broadcast" (Error `Cannot_NAT) >>= fun () ->
   (* try just an ethernet frame *)
   let e = Cstruct.create Ethernet_wire.sizeof_ethernet in
-  Nat_packet.of_ethernet_frame ~cache ~now:0L e |> Rresult.R.reword_error ignore
+  Nat_packet.of_ethernet_frame cache ~now:0L e |> Rresult.R.reword_error ignore
   |> Alcotest.(check (result (option packet_t) unit)) "Bare ethernet frame" (Error ());
   Lwt.return ()
 
@@ -442,6 +442,112 @@ let test_tcp_icmp_error () =
   >|= Alcotest.check translate_result "Map TCP (ICMP error)" (Ok error_reply_int) >>= fun () ->
   Lwt.return ()
 
+let gen_icmp size =
+  let data = Cstruct.create size
+  and src, dst = "1.1.1.1", "2.2.2.2"
+  and ttl = 64
+  in
+  let icmp = `Echo_request (5, 9, data) in
+  Constructors.make_icmp ~src ~dst icmp ~ttl
+
+let check_off data v =
+  Alcotest.(check int __LOC__ v (Cstruct.BE.get_uint16 data 6))
+
+let test_to_cstruct_fragmentation_simple () =
+  let packet = gen_icmp 1472 in
+  match Nat_packet.to_cstruct ~mtu:1500 packet with
+  | Ok [ data ] ->
+    Alcotest.(check int __LOC__ 1500 (Cstruct.len data));
+    check_off data 0x0000
+  | _ -> Alcotest.fail "expected to_cstruct to succeed"
+
+let test_to_cstruct_fragmentation_basic () =
+  let packet = gen_icmp 1500 in
+  match Nat_packet.to_cstruct ~mtu:1500 packet with
+  | Ok [ hd ; tl ] ->
+    Alcotest.(check int __LOC__ 1500 (Cstruct.len hd));
+    check_off hd 0x2000;
+    Alcotest.(check int __LOC__ 48 (Cstruct.len tl));
+    check_off tl 0x00B9
+  | _ -> Alcotest.fail "expected to_cstruct to succeed"
+
+let test_to_cstruct_fragmentation_three_full () =
+  let packet = gen_icmp 4432 in
+  match Nat_packet.to_cstruct ~mtu:1500 packet with
+  | Ok [ init; more; more' ] ->
+    Alcotest.(check int __LOC__ 1500 (Cstruct.len init));
+    Alcotest.(check int __LOC__ 1500 (Cstruct.len more));
+    Alcotest.(check int __LOC__ 1500 (Cstruct.len more'));
+    check_off init 0x2000;
+    check_off more 0x20B9;
+    check_off more' 0x0172
+  | _ -> Alcotest.fail "expected to_cstruct to succeed"
+
+let test_to_cstruct_fragmentation_error () =
+  (* puts don't fragment into IP header *)
+  let `IPv4 (ip, data) = gen_icmp 1473 in
+  let ip' = { ip with off = 0x4000 } in
+  let packet = `IPv4 (ip', data) in
+  match Nat_packet.to_cstruct ~mtu:1500 packet with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected to_cstruct to fail"
+
+let test_into_cstruct_fragmentation_simple () =
+  let packet = gen_icmp 1472 in
+  let cs = Cstruct.create 1500 in
+  match Nat_packet.into_cstruct packet cs with
+  | Ok (1500, []) -> check_off cs 0x0000
+  | _ -> Alcotest.fail "expected into_cstruct to succeed"
+
+let test_into_cstruct_fragmentation_basic () =
+  let packet = gen_icmp 1500 in
+  let cs = Cstruct.create 1500 in
+  match Nat_packet.into_cstruct packet cs with
+  | Ok (1500, [ tl ]) ->
+    check_off cs 0x2000;
+    Alcotest.(check int __LOC__ 48 (Cstruct.len tl));
+    check_off tl 0x00B9
+  | _ -> Alcotest.fail "expected into_cstruct to succeed"
+
+let test_into_cstruct_fragmentation_three_full () =
+  let packet = gen_icmp 4432 in
+  let cs = Cstruct.create 1500 in
+  match Nat_packet.into_cstruct packet cs with
+  | Ok (1500, [ more; more' ]) ->
+    check_off cs 0x2000;
+    check_off more 0x20B9;
+    check_off more' 0x0172
+  | _ -> Alcotest.fail "expected into_cstruct to succeed"
+
+let test_into_cstruct_fragmentation_error () =
+  (* puts don't fragment into IP header *)
+  let `IPv4 (ip, data) = gen_icmp 1473 in
+  let ip' = { ip with off = 0x4000 } in
+  let packet = `IPv4 (ip', data) in
+  let cs = Cstruct.create 1500 in
+  match Nat_packet.into_cstruct packet cs with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected into_cstruct to fail"
+
+let test_of_ipv4_packet_reassembly_basic () =
+  (* extensive reassembly tests (positive, negative, out-of-order, ...) are
+     in mirage-tcpip, here we just test basic operation *)
+  let packet = gen_icmp 1473 in
+  match Nat_packet.to_cstruct ~mtu:1500 packet with
+  | Ok [ init; more ] ->
+    let cache = Fragments.Cache.create (128 * 1024)
+    and now = 0L
+    in
+    begin match Nat_packet.of_ipv4_packet cache ~now init with
+      | Ok None ->
+        begin match Nat_packet.of_ipv4_packet cache ~now more with
+          | Ok Some pkt -> Alcotest.check packet_t __LOC__ packet pkt
+          | _ -> Alcotest.fail "expecting a packet"
+        end
+      | _ -> Alcotest.fail "expecting no packet"
+    end
+  | _ -> Alcotest.fail "to_cstruct failed"
+
 let lwt_run f () = Lwt_main.run (f ())
 
 let correct_mappings = [
@@ -468,6 +574,18 @@ let many_entries = [
       add_many_entries 200);
 ]
 
+let fragmentation = [
+  "to_cstruct no fragments", `Quick, test_to_cstruct_fragmentation_simple ;
+  "to_cstruct fragments", `Quick, test_to_cstruct_fragmentation_basic ;
+  "to_cstruct three fragments", `Quick, test_to_cstruct_fragmentation_three_full ;
+  "to_cstruct errors due to don't fragment", `Quick, test_to_cstruct_fragmentation_error ;
+  "into_cstruct no fragments", `Quick, test_into_cstruct_fragmentation_simple ;
+  "into_cstruct fragments", `Quick, test_into_cstruct_fragmentation_basic ;
+  "into_cstruct three fragments", `Quick, test_into_cstruct_fragmentation_three_full ;
+  "into_cstruct errors due to don't fragment", `Quick, test_into_cstruct_fragmentation_error ;
+  "of_ipv4_packet reassembles", `Quick, test_of_ipv4_packet_reassembly_basic ;
+]
+
 let () =
   Logs.set_reporter (Logs_fmt.reporter ());
   Logs.set_level ~all:true (Some Logs.Debug);
@@ -476,4 +594,5 @@ let () =
     "add_nat", add_nat;
     "add_redirect", add_redirect;
     "many_entries", many_entries;
+    "fragmentation", fragmentation;
   ]

--- a/mirage-nat.opam
+++ b/mirage-nat.opam
@@ -24,7 +24,7 @@ depends: [
   "lru" {>= "0.3.0"}
   "ppx_deriving" {build & >= "4.2" }
   "dune" {>= "1.0"}
-  "tcpip" { >= "3.7.2" }
+  "tcpip" { >= "3.7.8" }
   "ethernet" { >= "2.0.0" }
   "arp"
   "alcotest" {with-test}


### PR DESCRIPTION
This PR adds IPv4 fragmentation and reassembly support to mirage-nat. It relies on the code available in tcpip sice 3.7.8 for processing. There are some API changes:
- `of_ethernet_frame` and `of_ipv4_packet` reassembly ipv4 packets, and require additional parameters, a `Fragments.Cache.t`and a `~now:int64` for reassembly
- `to_cstruct` and `into_cstruct` fragment the payload if needed. 
  - `to_cstruct` takes an optional `~mtu:int` parameter (defaults to 1500) and outputs a flat list of fragments or an error (if the provided packet has the `don't fragment`bit sit). It used to return a list of `[ip_header ; transport_header ; payload ]`, which is now flattened into the first element
  - `into_cstruct` uses the length of the provided `Cstruct.t` as `mtu`, and returns in addition to the bytes written a list of further fragments. this is a slightly weird result type (since the initial fragment is specially crafted and directly written - while remaining ones are freshly allocated), but I failed to find a better solution. in the end, 99% packets fit into the fast path (no fragmentation).

I'd be happy if someone would review the code, it compiles, the tests are running. I plan to test this code a bit more this week, and may add tests for the fragmentation code paths.

This fixes #31 and unblocks #35. Once this is accepted and merged, we should publish a new release.