### PR TITLE
Implement remove_connections: evict all connections of a single IP address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ env:
     - PACKAGE="mirage-nat"
     - TESTS=true
   matrix:
-    - OCAML_VERSION=4.06 MIRAGE_BACKEND=unix
     - OCAML_VERSION=4.07 MIRAGE_BACKEND=qubes
     - OCAML_VERSION=4.08 MIRAGE_BACKEND=xen
-    - OCAML_VERSION=4.09 MIRAGE_BACKEND=spt
+    - OCAML_VERSION=4.09 MIRAGE_BACKEND=unix
+    - OCAML_VERSION=4.10 MIRAGE_BACKEND=spt
 os:
   - linux

--- a/example/unikernel.ml
+++ b/example/unikernel.ml
@@ -31,7 +31,7 @@ module Main
   let start public_netif private_netif
             public_ethernet private_ethernet
             public_arpv4 private_arpv4
-            public_ipv4 _private_ipv4 () () =
+            public_ipv4 _private_ipv4 _rng () =
 
     (* if writing a packet into a given memory buffer failed,
        log the failure, pass information on how much was written

--- a/lib/mirage_nat.ml
+++ b/lib/mirage_nat.ml
@@ -9,8 +9,14 @@ let pp_error f = function
   | `Untranslated -> Fmt.string f "Packet not translated"
   | `TTL_exceeded -> Fmt.string f "TTL exceeded"
 
+type ports = {
+  tcp : port list ;
+  udp : port list ;
+}
+
 module type S = sig
   type t
+  val remove_connections : t -> Ipaddr.V4.t -> ports
   val translate : t -> Nat_packet.t -> (Nat_packet.t, [> `Untranslated | `TTL_exceeded]) result Lwt.t
   val add : t -> Nat_packet.t -> endpoint -> [`NAT | `Redirect of endpoint] -> (unit, [> `Overlap | `Cannot_NAT]) result Lwt.t
   val reset : t -> unit Lwt.t
@@ -36,4 +42,6 @@ module type TABLE = sig
 
   val reset : t -> unit Lwt.t
   (** Remove all entries from the table. *)
+
+  val remove_connections : t -> Ipaddr.V4.t -> ports
 end

--- a/lib/mirage_nat.mli
+++ b/lib/mirage_nat.mli
@@ -10,8 +10,16 @@ type error = [
 
 val pp_error : [< error] Fmt.t
 
+type ports = {
+  tcp : port list ;
+  udp : port list ;
+}
+
 module type S = sig
   type t
+
+  val remove_connections : t -> Ipaddr.V4.t -> ports
+  (** [remove_connections t ip] removes all connections of [ip] in [t]. *)
 
   val translate : t -> Nat_packet.t -> (Nat_packet.t, [> `Untranslated | `TTL_exceeded]) result Lwt.t
   (** Given a lookup table and an ip-level packet,
@@ -89,4 +97,7 @@ module type TABLE = sig
 
   val reset : t -> unit Lwt.t
   (** Remove all entries from the table. *)
+
+  val remove_connections : t -> Ipaddr.V4.t -> ports
+  (** Remove all connections from and to the given IP address. *)
 end

--- a/lib/nat_rewrite.ml
+++ b/lib/nat_rewrite.ml
@@ -140,6 +140,7 @@ module Make(N : Mirage_nat.TABLE) = struct
   end
 
   let reset = N.reset
+  let remove_connections = N.remove_connections
 
   let translate_by_transport table (type t) (module P : PROTOCOL with type transport = t) ip (transport:P.transport) =
     match P.channel transport with


### PR DESCRIPTION
sometimes it is useful to drop all connections from a single client from the NAT table